### PR TITLE
[IP-17] 틈 노트 작성 화면 UI 구현, Firebase 임시 연결, Github Actions 수정

### DIFF
--- a/.github/actions/assignReviewer/assignReviewer.mjs
+++ b/.github/actions/assignReviewer/assignReviewer.mjs
@@ -22,23 +22,15 @@ import fetch from "node-fetch";
       actionType === "synchronize" ? "🔄 커밋이 추가되었습니다.\n" : "";
 
     let reviewer;
-    if (pr.requested_reviewers.length > 0) {
-      reviewer = REVIEWERS.find(
-        (r) => r.githubName === pr.requested_reviewers[0].login
-      );
-    } else {
-      const candidates = REVIEWER_CANDIDATES.filter((r) => r !== prAuthor);
-      const selected =
-        candidates[Math.floor(Math.random() * candidates.length)];
-      await octokit.rest.pulls.requestReviewers({
-        owner,
-        repo,
-        pull_number: pullNumber,
-        reviewers: [selected],
-      });
-      reviewer = REVIEWERS.find((r) => r.githubName === selected);
-    }
-
+    const candidates = REVIEWER_CANDIDATES.filter((r) => r !== prAuthor);
+    const selected = candidates[Math.floor(Math.random() * candidates.length)];
+    await octokit.rest.pulls.requestReviewers({
+      owner,
+      repo,
+      pull_number: pullNumber,
+      reviewers: [selected],
+    });
+    reviewer = REVIEWERS.find((r) => r.githubName === selected);
     if (pr.assignees.length === 0) {
       await octokit.rest.issues.addAssignees({
         owner,

--- a/teum/Manager/UserDefaultsManager.swift
+++ b/teum/Manager/UserDefaultsManager.swift
@@ -12,6 +12,7 @@ enum UserDefaultsKeys {
     static let name = "name"
     static let email = "email"
     static let profileImageURL = "profileImage"
+    static let isTeumNotePublic = "isTeumNotePrivate"
 }
 
 final class UserDefaultsManager {
@@ -21,6 +22,7 @@ final class UserDefaultsManager {
     @AppStorage(UserDefaultsKeys.name) var name: String = ""
     @AppStorage(UserDefaultsKeys.email) var email: String = ""
     @AppStorage(UserDefaultsKeys.profileImageURL) var profileImageURL: String = ""
+    @AppStorage(UserDefaultsKeys.isTeumNotePublic) var isTeumNotePublic: Bool = true    // 틈 노트 기본값은 공개로 설정
 
     private init() { }
 

--- a/teum/Model/Note.swift
+++ b/teum/Model/Note.swift
@@ -15,11 +15,11 @@ struct Note: Identifiable, Codable {
     var title: String                           // 노트 제목
     var date: Date                              // 노트를 작성한 날짜 (사용자 선택)
     var socialBattery: Int                      // 소셜 배터리, 현재는 Int 지만 기획에 따라 Double로 변경 가능
-    var placeName: String                       // 장소 이름
-    var latitude: Double?                      // 장소의 위도
-    var longitude: Double?                       // 장소의 경도
+    var district: String                        // 지역 이름 (예: "강남구", "중구")
+    // var latitude: Double?                       // 장소의 위도
+    // var longitude: Double?                      // 장소의 경도
     var content: String                         // 노트 내용
-    var imagePaths: [String]?                    // 이미지 경로 (Storage URL 또는 path), 최대 5개
+    var imagePaths: [String]?                   // 이미지 경로 (Storage URL 또는 path), 최대 5개
     var isPublic: Bool                          // 커뮤니티 공개 여부
     var createdAt: Date                         // 노트 생성 시각
     var updatedAt: Date?                        // 노트 수정 시각 (수정 시점, 없으면 nil), 이건 현재 필요 없다면 주석처리 하고 사용

--- a/teum/Views/TeumNote/FlipCard.swift
+++ b/teum/Views/TeumNote/FlipCard.swift
@@ -1,0 +1,38 @@
+//
+//  FlipCardView.swift
+//  teum
+//
+//  Created by junehee on 4/23/25.
+//
+
+import SwiftUI
+
+struct FlipCard: View {
+    
+    @Binding var flipped: Bool
+
+    var body: some View {
+        ZStack {
+            if flipped {
+                Text("Back")
+                    .rotation3DEffect(.degrees(180), axis: (x: 0, y: 1, z: 0))
+            } else {
+                Text("Front")
+            }
+        }
+        .frame(width: 300, height: 400)
+        .background(flipped ? .blue : .red)
+        .cornerRadius(10)
+        .onTapGesture {
+            withAnimation {
+                flipped.toggle()
+            }
+        }
+        .rotation3DEffect(.degrees(flipped ? 180 : 0), axis: (x: 0, y: 1, z: 0))
+    }
+    
+}
+
+#Preview {
+    FlipCard(flipped: .constant(false))
+}

--- a/teum/Views/TeumNote/TestView.swift
+++ b/teum/Views/TeumNote/TestView.swift
@@ -135,3 +135,6 @@ extension FireStoreManager {
         pprint("✅ 테스트 유저 저장 완료")
     }
 }
+
+
+

--- a/teum/Views/TeumNote/TestView.swift
+++ b/teum/Views/TeumNote/TestView.swift
@@ -16,8 +16,8 @@ struct FireStoreTestView: View {
     @State private var titleText: String = ""
     @State private var contentText: String = ""
     @State private var placeName: String = ""
-    @State private var latitude: String = ""
-    @State private var longitude: String = ""
+    // @State private var latitude: String = ""
+    // @State private var longitude: String = ""
     @State private var socialBattery: Double = 50
     @State private var selectedDate: Date = Date()
     @State private var isPublic: Bool = true

--- a/teum/Views/TeumNote/TestView.swift
+++ b/teum/Views/TeumNote/TestView.swift
@@ -13,8 +13,8 @@ import FirebaseFirestore
  https://console.firebase.google.com/project/teum-1d047/firestore/databases/-default-/data/~2FUsers~2Ftest-user?hl=ko&fb_gclid=CjwKCAjwk43ABhBIEiwAvvMEB_j08nLbdH75G5DBExUK3gjMApYDal1KAA9ql8CpLg8sgJf1UTKObhoC8_kQAvD_BwE
  */
 struct FireStoreTestView: View {
-    @State private var title: String = ""
-    @State private var content: String = ""
+    @State private var titleText: String = ""
+    @State private var contentText: String = ""
     @State private var placeName: String = ""
     @State private var latitude: String = ""
     @State private var longitude: String = ""
@@ -29,8 +29,8 @@ struct FireStoreTestView: View {
         NavigationStack {
             Form {
                 Section(header: Text("기본 정보")) {
-                    TextField("제목", text: $title)
-                    TextField("내용", text: $content)
+                    TextField("제목", text: $titleText)
+                    TextField("내용", text: $contentText)
                     DatePicker("날짜", selection: $selectedDate, displayedComponents: .date)
                     Toggle("커뮤니티 공개", isOn: $isPublic)
                 }
@@ -54,20 +54,20 @@ struct FireStoreTestView: View {
 
                 Button("노트 저장") {
                     Task {
-                        await saveNote()
+                        await saveNoteToFirestore()
                     }
                 }
             }
             .navigationTitle("테스트 노트 작성")
-            .alert("알림", isPresented: $showAlert) {
-                Button("확인", role: .cancel) { }
-            } message: {
-                Text(alertMessage)
-            }
+        }
+        .alert("알림", isPresented: $showAlert) {
+            Button("확인", role: .cancel) { }
+        } message: {
+            Text(alertMessage)
         }
     }
 
-    private func saveNote() async {
+    private func saveNoteToFirestore() async {
         let uid = "test-user"
 
         do {
@@ -78,24 +78,18 @@ struct FireStoreTestView: View {
             return
         }
 
-        guard let lat = Double(latitude), let lng = Double(longitude) else {
-            alertMessage = "위도/경도를 올바르게 입력해주세요."
-            showAlert = true
-            return
-        }
-
         let note = Note(
             id: nil,
             userId: uid,
-            title: title,
+            title: titleText,
             date: selectedDate,
-            socialBattery: Int(socialBattery),
-            placeName: placeName,
-            latitude: lat,
-            longitude: lng,
-            content: content,
+            socialBattery: 50,
+            placeName: "",
+            latitude: 0,
+            longitude: 0,
+            content: contentText,
             imagePaths: [],
-            isPublic: isPublic,
+            isPublic: true,
             createdAt: Date(),
             updatedAt: nil
         )
@@ -135,6 +129,3 @@ extension FireStoreManager {
         pprint("✅ 테스트 유저 저장 완료")
     }
 }
-
-
-

--- a/teum/Views/TeumNote/TeumNoteWriteView.swift
+++ b/teum/Views/TeumNote/TeumNoteWriteView.swift
@@ -13,6 +13,7 @@ struct TeumNoteWriteView: View {
     
     @State private var titleText = ""
     @State private var selectedDate = Date()
+    @State private var selectedDistrict: SeoulDistrict = .gangnam
     @State private var contentText = ""
     @State private var selectedPhotos: [PhotosPickerItem] = []
     @State private var selectedUIImages: [UIImage] = []
@@ -20,10 +21,71 @@ struct TeumNoteWriteView: View {
     @State private var showAlert = false
     @State private var alertMessage = ""
     
+    enum SeoulDistrict: String, CaseIterable {
+        case gangnam
+        case gangdong
+        case gangbuk
+        case gangseo
+        case gwanak
+        case gwangjin
+        case guro
+        case geumcheon
+        case nowon
+        case dobong
+        case dongdaemun
+        case dongjak
+        case mapo
+        case seodaemun
+        case seocho
+        case seongdong
+        case seongbuk
+        case songpa
+        case yangcheon
+        case yeongdeungpo
+        case yongsan
+        case eunpyeong
+        case jongno
+        case jung
+        case jungnang
+
+        var koreanName: String {
+            switch self {
+            case .gangnam: return "강남구"
+            case .gangdong: return "강동구"
+            case .gangbuk: return "강북구"
+            case .gangseo: return "강서구"
+            case .gwanak: return "관악구"
+            case .gwangjin: return "광진구"
+            case .guro: return "구로구"
+            case .geumcheon: return "금천구"
+            case .nowon: return "노원구"
+            case .dobong: return "도봉구"
+            case .dongdaemun: return "동대문구"
+            case .dongjak: return "동작구"
+            case .mapo: return "마포구"
+            case .seodaemun: return "서대문구"
+            case .seocho: return "서초구"
+            case .seongdong: return "성동구"
+            case .seongbuk: return "성북구"
+            case .songpa: return "송파구"
+            case .yangcheon: return "양천구"
+            case .yeongdeungpo: return "영등포구"
+            case .yongsan: return "용산구"
+            case .eunpyeong: return "은평구"
+            case .jongno: return "종로구"
+            case .jung: return "중구"
+            case .jungnang: return "중랑구"
+            }
+        }
+    }
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             titleFieldView()
-            datePickerView()
+            HStack {
+                datePickerView()
+                districtPickerView()
+            }
             contentFieldView()
             photoPickerView()
             selectedPhotoPreviewView()
@@ -31,6 +93,7 @@ struct TeumNoteWriteView: View {
         }
         .padding(.top, 30)
         .padding(.horizontal, 20)
+        .background(Color.softLavender.opacity(0.5))
         .alert("알림", isPresented: $showAlert) {
             Button("확인", role: .cancel) { }
         } message: {
@@ -39,35 +102,44 @@ struct TeumNoteWriteView: View {
     }
     
     private func titleFieldView() -> some View {
-        TextField("제목을 입력해 주세요.", text: $titleText, prompt: Text("제목을 입력해 주세요."))
+        TextField("제목", text: $titleText, prompt: Text("오늘 혼놀은 어떠셨어요?"))
             .bold()
             .font(.title2)
     }
     
     private func datePickerView() -> some View {
         VStack(alignment: .leading, spacing: 4) {
-            DatePicker("날짜를 선택해 주세요.", selection: $selectedDate, displayedComponents: [.date])
+            DatePicker("날짜", selection: $selectedDate, displayedComponents: [.date])
                 .datePickerStyle(.compact)
                 .labelsHidden()
+                .background(Color.gray.opacity(0.1))
+                .cornerRadius(8)
+                
         }
+    }
+    
+    private func districtPickerView() -> some View {
+        Picker("구를 선택해 주세요.", selection: $selectedDistrict) {
+            ForEach(SeoulDistrict.allCases, id: \.self) { district in
+                Text(district.koreanName).tag(district.rawValue)
+            }
+        }
+        .pickerStyle(.menu)
+        .foregroundStyle(.black)
+        .background(Color.gray.opacity(0.2))
+        .cornerRadius(8)
     }
     
     private func contentFieldView() -> some View {
         ZStack {
-            // background
-            RoundedRectangle(cornerRadius: 8)
-                .stroke(.gray, lineWidth: 1)
-            
-            // content
             TextEditor(text: $contentText)
                 .background(.clear)
                 .overlay(alignment: .topLeading) {
                     Text("내용을 입력해 주세요.")
                         .foregroundStyle(contentText.isEmpty ? .gray : .clear)
-                        .padding(10)
+                        .padding(12)
                         .allowsHitTesting(false)
                 }
-                .border(.gray)
                 .clipShape(.rect(cornerRadius: 10))
         }
     }
@@ -121,10 +193,11 @@ struct TeumNoteWriteView: View {
                         }) {
                             Image(systemName: "xmark.circle.fill")
                                 .foregroundColor(.white)
+                                .padding(4)
                                 .background(Color.black.opacity(0.6))
                                 .clipShape(Circle())
                         }
-                        .offset(x: 5, y: -5)
+                        .offset(x: -5, y: 5)
                     }
                 }
             }
@@ -137,12 +210,12 @@ struct TeumNoteWriteView: View {
                 await saveNoteToFirestore()
             }
         } label: {
-            Text("SAVE")
+            Text("기록하기")
                 .font(.headline)
                 .foregroundColor(.white)
                 .frame(maxWidth: .infinity)
                 .padding()
-                .background(Color.blue)
+                .background(Color.deepNavyBlue)
                 .cornerRadius(10)
         }
         

--- a/teum/Views/TeumNote/TeumNoteWriteView.swift
+++ b/teum/Views/TeumNote/TeumNoteWriteView.swift
@@ -1,0 +1,145 @@
+//
+//  TeumNoteWriteView.swift
+//  teum
+//
+//  Created by junehee on 4/22/25.
+//
+
+import SwiftUI
+import PhotosUI
+
+struct TeumNoteWriteView: View {
+    
+    @State private var titleText = ""
+    @State private var selectedDate = Date()
+    @State private var contentText = ""
+    @State private var selectedPhotos: [PhotosPickerItem] = []
+    @State private var selectedUIImages: [UIImage] = []
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            titleFieldView()
+            datePickerView()
+            contentFieldView()
+            photoPickerView()
+            selectedPhotoPreviewView()
+            saveButton()
+        }
+        .padding(.top, 30)
+        .padding(.horizontal, 20)
+    }
+    
+    private func titleFieldView() -> some View {
+        TextField("제목을 입력해 주세요.", text: $titleText, prompt: Text("제목을 입력해 주세요."))
+            .bold()
+            .font(.title2)
+    }
+    
+    private func datePickerView() -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            DatePicker("날짜를 선택해 주세요.", selection: $selectedDate, displayedComponents: [.date])
+                .datePickerStyle(.compact)
+                .labelsHidden()
+        }
+    }
+    
+    private func contentFieldView() -> some View {
+        ZStack {
+            // background
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(.gray, lineWidth: 1)
+            
+            // content
+            TextEditor(text: $contentText)
+                .background(.clear)
+                .overlay(alignment: .topLeading) {
+                    Text("내용을 입력해 주세요.")
+                        .foregroundStyle(contentText.isEmpty ? .gray : .clear)
+                        .padding(10)
+                        .allowsHitTesting(false)
+                }
+                .border(.gray)
+                .clipShape(.rect(cornerRadius: 10))
+        }
+    }
+    
+    private func photoPickerView() -> some View {
+        Group {
+            if selectedUIImages.count < 5 {
+                PhotosPicker(
+                    selection: $selectedPhotos,
+                    maxSelectionCount: 5,
+                    matching: .images,
+                    photoLibrary: .shared()
+                ) {
+                    HStack {
+                        Image(systemName: "photo")
+                    }
+                    .padding()
+                    .background(Color.gray.opacity(0.2))
+                    .cornerRadius(8)
+                }
+                .onChange(of: selectedPhotos) {
+                    Task {
+                        selectedUIImages = []
+                        for item in selectedPhotos {
+                            if let data = try? await item.loadTransferable(type: Data.self),
+                               let image = UIImage(data: data) {
+                                selectedUIImages.append(image)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    private func selectedPhotoPreviewView() -> some View {
+        ScrollView(.horizontal) {
+            HStack(spacing: 10) {
+                ForEach(Array(selectedUIImages.enumerated()), id: \.element) { idx, image in
+                    ZStack(alignment: .topTrailing) {
+                        Image(uiImage: image)
+                            .resizable()
+                            .scaledToFill()
+                            .frame(width: 100, height: 100)
+                            .clipped()
+                            .cornerRadius(8)
+
+                        Button(action: {
+                            selectedUIImages.remove(at: idx)
+                            selectedPhotos.remove(at: idx)
+                        }) {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundColor(.white)
+                                .background(Color.black.opacity(0.6))
+                                .clipShape(Circle())
+                        }
+                        .offset(x: 5, y: -5)
+                    }
+                }
+            }
+        }
+    }
+    
+    private func saveButton() -> some View {
+        Button {
+            print("저장 버튼 클릭")
+        } label: {
+            Text("SAVE")
+                .font(.headline)
+                .foregroundColor(.white)
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(Color.blue)
+                .cornerRadius(10)
+        }
+        
+    }
+
+}
+
+
+#Preview {
+    TeumNoteWriteView()
+}

--- a/teum/Views/TeumNote/TeumNoteWriteView.swift
+++ b/teum/Views/TeumNote/TeumNoteWriteView.swift
@@ -238,12 +238,10 @@ struct TeumNoteWriteView: View {
             title: titleText,
             date: selectedDate,
             socialBattery: 50,
-            placeName: "",
-            latitude: 0,
-            longitude: 0,
+            district: selectedDistrict.rawValue,
             content: contentText,
-            imagePaths: [],
-            isPublic: true,
+            imagePaths: [],  // TODO: 이미지 어떻게 저장할건지 논의 필요
+            isPublic: UserDefaultsManager.shared.isTeumNotePublic,
             createdAt: Date(),
             updatedAt: nil
         )
@@ -251,6 +249,7 @@ struct TeumNoteWriteView: View {
         do {
             try await FireStoreManager.shared.addNote(note)
             alertMessage = "노트 저장 성공! (userId: \(uid))"
+            UserDefaultsManager.shared.isTeumNotePublic = true  // 기본값으로 다시 설정
         } catch {
             alertMessage = "노트 저장 실패: \(error.localizedDescription)"
         }


### PR DESCRIPTION
## 🚀 작업 내용
- 틈 노트 작성 화면 UI 구현
- 기록하기 버튼 클릭 > Firebase DB 저장 임시 연결 (이미지 관련 수정 필요)
- Github Actions workflow 수정 (리뷰어 랜덤 지정...)

<br />

## ⛓️ 관련 티켓
https://ipari282.atlassian.net/browse/IP-17

<br />

## 📱 스크린샷
<img width="343" alt="스크린샷 2025-04-25 오후 10 21 19" src="https://github.com/user-attachments/assets/e9b71d41-5036-408f-b966-27165b31878f" />

<br /><br />

## 📝 메모
너무어려워요....스유 다 까먹었어요....
