### PR TITLE
[IP-18] 틈 노트 작성 화면 변경, 틈 노트 화면 플로팅 버튼 추가

### DIFF
--- a/teum.xcodeproj/project.pbxproj
+++ b/teum.xcodeproj/project.pbxproj
@@ -8,9 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		BFB8F2D82DB77D4F00C5A7CB /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = BFB8F2D72DB77D4F00C5A7CB /* GoogleSignIn */; };
-		BFB8F2E92DB8BF0700C5A7CB /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = BFB8F2E82DB8BF0700C5A7CB /* GoogleService-Info.plist */; };
 		C4182EA22DA26B97006EF403 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4182EA12DA26B97006EF403 /* ContentView.swift */; };
 		C4182EA72DA26B9A006EF403 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C4182EA62DA26B9A006EF403 /* Preview Assets.xcassets */; };
+		C425804B2DBE56C00002A225 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = C425804A2DBE56C00002A225 /* GoogleService-Info.plist */; };
 		F138A1622DAF5FA2000A6DE9 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = F138A1612DAF5FA2000A6DE9 /* FirebaseAuth */; };
 		F138A1642DAF5FA2000A6DE9 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = F138A1632DAF5FA2000A6DE9 /* FirebaseCrashlytics */; };
 		F138A1662DAF5FA2000A6DE9 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = F138A1652DAF5FA2000A6DE9 /* FirebaseFirestore */; };
@@ -20,11 +20,11 @@
 		BFB8F2B62DB36B7500C5A7CB /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
 		BFB8F2B72DB36CAA00C5A7CB /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		BFB8F2E52DB8828A00C5A7CB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		BFB8F2E82DB8BF0700C5A7CB /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		BFB8F2EA2DB8C13400C5A7CB /* teum.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = teum.entitlements; sourceTree = "<group>"; };
 		C4182E9C2DA26B97006EF403 /* teum.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = teum.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C4182EA12DA26B97006EF403 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		C4182EA62DA26B9A006EF403 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		C425804A2DBE56C00002A225 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -79,7 +79,7 @@
 			isa = PBXGroup;
 			children = (
 				BFB8F2EA2DB8C13400C5A7CB /* teum.entitlements */,
-				BFB8F2E82DB8BF0700C5A7CB /* GoogleService-Info.plist */,
+				C425804A2DBE56C00002A225 /* GoogleService-Info.plist */,
 				BFB8F2E52DB8828A00C5A7CB /* Info.plist */,
 				F138A1272DAE4119000A6DE9 /* Security */,
 				F138A0D62DAE0FC6000A6DE9 /* Views */,
@@ -192,7 +192,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C4182EA72DA26B9A006EF403 /* Preview Assets.xcassets in Resources */,
-				BFB8F2E92DB8BF0700C5A7CB /* GoogleService-Info.plist in Resources */,
+				C425804B2DBE56C00002A225 /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/teum/ContentView.swift
+++ b/teum/ContentView.swift
@@ -27,7 +27,7 @@ struct ContentView: View {
                         Image(systemName: "2.square.fill")
                         Text("커뮤니티")
                     }
-                FireStoreTestView()
+                TeumNoteView()
                     .tabItem {
                         Image(systemName: "3.square.fill")
                         Text("틈노트")

--- a/teum/Manager/UserDefaultsManager.swift
+++ b/teum/Manager/UserDefaultsManager.swift
@@ -12,7 +12,6 @@ enum UserDefaultsKeys {
     static let name = "name"
     static let email = "email"
     static let profileImageURL = "profileImage"
-    static let isTeumNotePublic = "isTeumNotePrivate"
 }
 
 final class UserDefaultsManager {
@@ -22,7 +21,6 @@ final class UserDefaultsManager {
     @AppStorage(UserDefaultsKeys.name) var name: String = ""
     @AppStorage(UserDefaultsKeys.email) var email: String = ""
     @AppStorage(UserDefaultsKeys.profileImageURL) var profileImageURL: String = ""
-    @AppStorage(UserDefaultsKeys.isTeumNotePublic) var isTeumNotePublic: Bool = true    // 틈 노트 기본값은 공개로 설정
 
     private init() { }
 

--- a/teum/Model/Note.swift
+++ b/teum/Model/Note.swift
@@ -24,3 +24,21 @@ struct Note: Identifiable, Codable {
     var createdAt: Date                         // 노트 생성 시각
     var updatedAt: Date?                        // 노트 수정 시각 (수정 시점, 없으면 nil), 이건 현재 필요 없다면 주석처리 하고 사용
 }
+
+extension Note {
+    static var mocking: [Note] {
+        (0..<30).map { index in
+            Note(
+                userId: "test-user",
+                title: "Test Note \(index + 1)",
+                date: Calendar.current.date(byAdding: .day, value: -index, to: Date()) ?? Date(),
+                socialBattery: Double.random(in: 1...100),
+                district: ["강남구", "서초구", "마포구", "성동구", "종로구"].randomElement() ?? "강남구",
+                content: "이것은 테스트용 노트입니다. 인덱스: \(index + 1)",
+                imagePaths: [],
+                isPublic: Bool.random(),
+                createdAt: Date(),
+            )
+        }
+    }
+}

--- a/teum/Model/Note.swift
+++ b/teum/Model/Note.swift
@@ -14,7 +14,7 @@ struct Note: Identifiable, Codable {
     var userId: String                          // 작성한 사용자 UID (Auth 기반)
     var title: String                           // 노트 제목
     var date: Date                              // 노트를 작성한 날짜 (사용자 선택)
-    var socialBattery: Int                      // 소셜 배터리, 현재는 Int 지만 기획에 따라 Double로 변경 가능
+    var socialBattery: Double                      // 소셜 배터리, 현재는 Int 지만 기획에 따라 Double로 변경 가능
     var district: String                        // 지역 이름 (예: "강남구", "중구")
     // var latitude: Double?                       // 장소의 위도
     // var longitude: Double?                      // 장소의 경도

--- a/teum/Views/TeumNote/FlipCard.swift
+++ b/teum/Views/TeumNote/FlipCard.swift
@@ -28,7 +28,7 @@ struct FlipCard: View {
                 flipped.toggle()
             }
         }
-        .rotation3DEffect(.degrees(flipped ? 180 : 0), axis: (x: 0, y: 1, z: 0))
+        .rotation3DEffect(.degrees(flipped ? 180 : 0), axis: (x: 0, y: -1, z: 0))
     }
     
 }

--- a/teum/Views/TeumNote/TestView.swift
+++ b/teum/Views/TeumNote/TestView.swift
@@ -37,10 +37,10 @@ struct FireStoreTestView: View {
 
                 Section(header: Text("장소")) {
                     TextField("장소 이름", text: $placeName)
-                    TextField("위도", text: $latitude)
-                        .keyboardType(.decimalPad)
-                    TextField("경도", text: $longitude)
-                        .keyboardType(.decimalPad)
+                    // TextField("위도", text: $latitude)
+                    //     .keyboardType(.decimalPad)
+                    // TextField("경도", text: $longitude)
+                    //     .keyboardType(.decimalPad)
                 }
 
                 Section(header: Text("소셜 배터리")) {
@@ -84,9 +84,9 @@ struct FireStoreTestView: View {
             title: titleText,
             date: selectedDate,
             socialBattery: 50,
-            placeName: "",
-            latitude: 0,
-            longitude: 0,
+            district: "",
+            // latitude: 0,
+            // longitude: 0,
             content: contentText,
             imagePaths: [],
             isPublic: true,

--- a/teum/Views/TeumNote/TeumNoteView.swift
+++ b/teum/Views/TeumNote/TeumNoteView.swift
@@ -8,8 +8,82 @@
 import SwiftUI
 
 struct TeumNoteView: View {
+    
+    @State private var myNotes: [Note] = []
+    @State private var showOptions = false
+    @State private var navigateToWriteView = false
+    @State private var flippedStates: [Bool] = []
+    
+    
     var body: some View {
-        Text("TeumNoteView")
+        NavigationStack {
+            ZStack(alignment: .bottomTrailing) {
+                // 스크롤뷰
+                ScrollView {
+                    LazyVStack(spacing: 16) {
+                        ForEach(Array(flippedStates.enumerated()), id: \.offset) { index, _ in
+                            FlipCard(flipped: $flippedStates[index])
+                                .onTapGesture {
+                                    flippedStates[index].toggle()
+                                }
+                        }
+                    }
+                }
+                .padding()
+                
+                // 플로팅 버튼
+                if showOptions {
+                    VStack(spacing: 12) {
+                        Button(action: {
+                            navigateToWriteView = true
+                        }) {
+                            Image(systemName: "square.and.pencil")
+                                .font(.system(size: 20))
+                                .foregroundColor(.white)
+                                .frame(width: 50, height: 50)
+                                .background(Color.blue)
+                                .clipShape(Circle())
+                        }
+                        Button(action: {
+                            navigateToWriteView = true
+                        }) {
+                            Image(systemName: "pencil")
+                                .font(.system(size: 20))
+                                .foregroundColor(.white)
+                                .frame(width: 50, height: 50)
+                                .background(Color.green)
+                                .clipShape(Circle())
+                        }
+                    }
+                    .offset(x: -5, y: 10)
+                    .transition(.scale)
+                }
+                
+                Button {
+                    withAnimation { showOptions.toggle() }
+                } label: {
+                    Image(systemName: "square.and.pencil")
+                        .font(.system(size: 20))
+                        .foregroundColor(.white)
+                        .frame(width: 40, height: 40)
+                        .background(Color.mainColor)
+                        .clipShape(Circle())
+                        .padding()
+                }
+            }
+            .navigationDestination(isPresented: $navigateToWriteView) {
+                TeumNoteWriteView()
+            }
+            .onAppear {
+                if flippedStates.count < 20 {
+                    flippedStates = Array(repeating: false, count: 20)
+                }
+            }
+        }
     }
+    
 }
 
+#Preview {
+    TeumNoteView()
+}

--- a/teum/Views/TeumNote/TeumNoteView.swift
+++ b/teum/Views/TeumNote/TeumNoteView.swift
@@ -10,76 +10,71 @@ import SwiftUI
 struct TeumNoteView: View {
     
     @State private var myNotes: [Note] = []
-    @State private var showOptions = false
-    @State private var navigateToWriteView = false
-    @State private var flippedStates: [Bool] = []
-    
+    @State private var navigateToWriteView = false  // TODO: 네비게이션 관리 필요
     
     var body: some View {
         NavigationStack {
             ZStack(alignment: .bottomTrailing) {
-                // 스크롤뷰
-                ScrollView {
-                    LazyVStack(spacing: 16) {
-                        ForEach(Array(flippedStates.enumerated()), id: \.offset) { index, _ in
-                            FlipCard(flipped: $flippedStates[index])
-                                .onTapGesture {
-                                    flippedStates[index].toggle()
-                                }
-                        }
-                    }
-                }
-                .padding()
-                
-                // 플로팅 버튼
-                if showOptions {
-                    VStack(spacing: 12) {
-                        Button(action: {
-                            navigateToWriteView = true
-                        }) {
-                            Image(systemName: "square.and.pencil")
-                                .font(.system(size: 20))
-                                .foregroundColor(.white)
-                                .frame(width: 50, height: 50)
-                                .background(Color.blue)
-                                .clipShape(Circle())
-                        }
-                        Button(action: {
-                            navigateToWriteView = true
-                        }) {
-                            Image(systemName: "pencil")
-                                .font(.system(size: 20))
-                                .foregroundColor(.white)
-                                .frame(width: 50, height: 50)
-                                .background(Color.green)
-                                .clipShape(Circle())
-                        }
-                    }
-                    .offset(x: -5, y: 10)
-                    .transition(.scale)
-                }
-                
-                Button {
-                    withAnimation { showOptions.toggle() }
-                } label: {
-                    Image(systemName: "square.and.pencil")
-                        .font(.system(size: 20))
-                        .foregroundColor(.white)
-                        .frame(width: 40, height: 40)
-                        .background(Color.mainColor)
-                        .clipShape(Circle())
-                        .padding()
-                }
+                titleView()
+                myNoteList()
+                floatingButton()
             }
             .navigationDestination(isPresented: $navigateToWriteView) {
                 TeumNoteWriteView()
             }
-            .onAppear {
-                if flippedStates.count < 20 {
-                    flippedStates = Array(repeating: false, count: 20)
+            .task {
+                do {
+                    let data = try await FireStoreManager.shared.fetchPublicNotes()
+                    myNotes = data
+                } catch {
+                    pprint("Error fetching notes: \(error.localizedDescription)")
                 }
             }
         }
+    }
+    
+    private func titleView() -> some View {
+        // TODO: 다른 화면 보고 디자인 맞춰야 함
+        VStack {
+            HStack {
+                Text("내 노트")
+                    .font(.system(size: 20))
+                    .fontWeight(.bold)
+                    .foregroundColor(.black)
+                Spacer()
+            }
+            .padding(.horizontal)
+            Spacer()
+        }
+    }
+    
+    private func myNoteList() -> some View {
+        ScrollView {
+            LazyVStack(spacing: 16) {
+                ForEach(myNotes, id: \.id) { note in
+                    FlipCard(flipped: .constant(false))
+                        .onTapGesture {
+                            // 카드 뒤집기 로직 추가 필요
+                        }
+                }
+            }
+        }
+        .padding()
+    }
+    
+    private func floatingButton() -> some View {
+        Button {
+            navigateToWriteView = true
+        } label: {
+            Image(systemName: "square.and.pencil")
+                .font(.system(size: 20))
+                .foregroundColor(.white)
+                .frame(width: 40, height: 40)
+                .background(Color.mainColor)
+                .clipShape(Circle())
+                .padding()
+        }
+        .padding(.bottom)
     }
     
 }

--- a/teum/Views/TeumNote/TeumNoteWriteView.swift
+++ b/teum/Views/TeumNote/TeumNoteWriteView.swift
@@ -14,6 +14,7 @@ struct TeumNoteWriteView: View {
     @State private var titleText = ""
     @State private var selectedDate = Date()
     @State private var selectedDistrict: SeoulDistrict = .gangnam
+    @State private var isPublic: Bool = true
     @State private var socialBattery: Double = 50
     @State private var contentText = ""
     
@@ -88,6 +89,7 @@ struct TeumNoteWriteView: View {
                     TextField("제목", text: $titleText)
                     DatePicker("날짜", selection: $selectedDate, displayedComponents: .date)
                     districtPickerView()
+                    Toggle("공개", isOn: $isPublic)
                 }
                 Section {
                     contentFieldView()
@@ -117,22 +119,6 @@ struct TeumNoteWriteView: View {
         .background(Color(UIColor.systemGroupedBackground))
     }
     
-    private func titleFieldView() -> some View {
-        TextField("제목", text: $titleText, prompt: Text("오늘 혼놀은 어떠셨어요?"))
-            .bold()
-            .font(.title2)
-    }
-    
-    private func datePickerView() -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            DatePicker("날짜", selection: $selectedDate, displayedComponents: [.date])
-                .datePickerStyle(.compact)
-                .labelsHidden()
-                .background(Color.gray.opacity(0.1))
-                .cornerRadius(8)
-                
-        }
-    }
     
     private func districtPickerView() -> some View {
         Picker("장소", selection: $selectedDistrict) {
@@ -152,6 +138,7 @@ struct TeumNoteWriteView: View {
                     .padding(12)
                     .allowsHitTesting(false)
             }
+            .frame(maxWidth: .infinity, maxHeight: 200)
     }
     
     private func photoPickerView() -> some View {
@@ -229,7 +216,7 @@ struct TeumNoteWriteView: View {
                 .background(Color.deepNavyBlue)
                 .cornerRadius(10)
         }
-        .padding(.horizontal)
+        .padding([.horizontal, .bottom])
     }
     
     private func saveNoteToFirestore() async {
@@ -251,18 +238,17 @@ struct TeumNoteWriteView: View {
             district: selectedDistrict.rawValue,
             content: contentText,
             imagePaths: [],  // TODO: 이미지 어떻게 저장할건지 논의 필요
-            isPublic: UserDefaultsManager.shared.isTeumNotePublic,
+            isPublic: isPublic,
             createdAt: Date(),
         )
 
         do {
             try await FireStoreManager.shared.addNote(note)
             alertMessage = "노트 저장 성공! (userId: \(uid))"
-            UserDefaultsManager.shared.isTeumNotePublic = true  // 기본값으로 다시 설정
         } catch {
             alertMessage = "노트 저장 실패: \(error.localizedDescription)"
         }
-
+        
         showAlert = true
     }
 


### PR DESCRIPTION
## 🚀 작업 내용
- UserDefault로 관리하던 틈 노트 공개 여부를 다시 작성 화면에서 관리하도록 수정합니다.
- 플로팅 버튼에 옵션을 지우고 바로 글쓰기 화면으로 넘어가도록 합니다.

<br />

## ⛓️ 관련 티켓
https://ipari282.atlassian.net/browse/IP-18

<br />

## 📱 스크린샷
<!-- 작업 결과 스크린샷 기록 -->

<br /><br />

## 📝 메모
- 틈 노트 > 틈노트 작성 화면으로 넘어가는 부분에 Coodinator로 관리 필요한데 일단 급해서 임시 코드입니다. 나중에 하겠습니다!
