### PR TITLE
[Fix] 틈 노트 본인 데이터만 불러오도록 수정, 화면 pop 처리

### DIFF
--- a/teum/Views/TeumNote/FlipCard.swift
+++ b/teum/Views/TeumNote/FlipCard.swift
@@ -15,13 +15,13 @@ struct FlipCard: View {
 
     var body: some View {
         ZStack {
-            if flipped {
+            if !flipped {
                 Text(front)
-                    .foregroundStyle(Color.softLavender)
-                    .rotation3DEffect(.degrees(180), axis: (x: 0, y: 1, z: 0))
+                    .foregroundStyle(Color.midnightBlue)
             } else {
                 Text(back)
-                    .foregroundStyle(Color.midnightBlue)
+                    .foregroundStyle(Color.softLavender)
+                    .rotation3DEffect(.degrees(180), axis: (x: 0, y: 1, z: 0))
             }
         }
         .frame(width: 300, height: 400)

--- a/teum/Views/TeumNote/TeumNoteView.swift
+++ b/teum/Views/TeumNote/TeumNoteView.swift
@@ -23,7 +23,7 @@ struct TeumNoteView: View {
         }
         .task {
             do {
-                let data = try await FireStoreManager.shared.fetchPublicNotes()
+                let data = try await FireStoreManager.shared.fetchMyNotes()
                 myNotes = data
                 flippedStates = Dictionary(uniqueKeysWithValues: data.compactMap {
                     guard let id = $0.id else { return nil }

--- a/teum/Views/TeumNote/TeumNoteWriteView.swift
+++ b/teum/Views/TeumNote/TeumNoteWriteView.swift
@@ -120,7 +120,9 @@ struct TeumNoteWriteView: View {
                    }
                }
                .alert("알림", isPresented: $showAlert) {
-                   Button("확인", role: .cancel) { }
+                   Button("확인", role: .cancel) {
+                       coorinator.pop()
+                   }
                } message: {
                    Text(alertMessage)
                }
@@ -276,9 +278,11 @@ struct TeumNoteWriteView: View {
 
         do {
             try await FireStoreManager.shared.addNote(note)
-            alertMessage = "노트 저장 성공! (userId: \(uid))"
+            alertMessage = "노트 저장 성공!"
+            pprint("노트 저장 성공 userId: \(uid)")
         } catch {
-            alertMessage = "노트 저장 실패: \(error.localizedDescription)"
+            alertMessage = "노트 저장 실패"
+            pprint("\(error.localizedDescription)")
         }
 
         showAlert = true


### PR DESCRIPTION
## 🚀 작업 내용
- 틈 노트 데이터 불러올 때 본인이 작성한 데이터만 불러오도록 수정합니다.
- 틈 노트 작성 성공 시 화면을 pop 처리하고 이전 목록 화면이 나오도록 수정합니다.

<br />

## ⛓️ 관련 티켓
- 티켓 없이 작업했습니다!

<br />

## 📱 스크린샷

https://github.com/user-attachments/assets/f40c1fb8-af2e-4830-8372-aa404652385f


<br /><br />

## 📝 메모

<!-- 없으면 삭제! -->
